### PR TITLE
Benchmarks for `fmt`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ matrix:
   include:
     - env: CABALVER=1.16 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - export PATH=/opt/happy/1.19.5/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,10 @@ install:
    fi
  - travis_retry cabal update -v
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - if [ "$GHCVER" == "7.6.3" ];
+   then cabal install --only-dependencies --enable-tests --dry -v > installplan.txt;
+   else cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt;
+   fi
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
@@ -54,7 +57,10 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     if [ "$GHCVER" == "7.6.3" ];
+       then cabal install --only-dependencies --enable-tests;
+       else cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     fi
    fi
 
 # snapshot package-db on cache miss
@@ -70,8 +76,13 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build --ghc-options=-Werror   # this builds all libraries and executables (including tests/benchmarks)
+   # -v2 provides useful information for debugging
+ - if [ "$GHCVER" == "7.6.3" ];
+   then cabal configure --enable-tests -v2;
+   else cabal configure --enable-tests --enable-benchmarks -v2;
+   fi
+   # this builds all libraries and executables (including tests/benchmarks
+ - cabal build --ghc-options=-Werror
  - cabal test
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -16,7 +16,8 @@ import qualified Data.Text.Format        as TF
 import           Data.Text.Format.Params as TF
 import qualified Data.Text.Lazy          as LT
 import           Fmt                     (( #| ), (|#))
-import           Formatting              (formatToString, int, sformat, (%))
+import           Formatting              (formatToString, int, sformat, stext, string,
+                                          (%))
 import           Text.Printf             (printf)
 
 import           Criterion               (Benchmark, bench, bgroup, nf)
@@ -77,6 +78,24 @@ main = defaultMain
       , taggedB "interpolate" $ \(a,b) -> [i|hello #{a} world #{b}|]
       , taggedB "show"        $ \(a,b) -> "hello " ++ show a ++ " world " ++ show b
       , taggedB "printf"      $ \(a,b) -> printf "hello %d world %d" a b
+      ]
+    ]
+  , bgroup "readme"
+    [ bTextGroup (9 :: Int, "Beijing" :: Text)
+      [ taggedB "fmt"         $ \(n,city) -> "There are "#|n|#" million bicycles in "#|city|#"."
+      , taggedB "formattting" $ \(n,city) -> sformat ("There are "%int%" million bicycles in "%stext%".") n city
+      , taggedB "text-format" $ format' "There are {} million bicycles in {}."
+      , taggedB "interpolate" $ \(n,city) -> T.pack [i|There are #{n} million bicycles in #{city}.|]
+      , taggedB "show"        $ \(n,city) -> "There are " <> tshow n <> " million bicycles in " <> city <> "."
+      , taggedB "printf"      $ \(n,city) -> T.pack $ printf "There are %d million bicycles in %s." n city
+      ]
+    , bStringGroup (9 :: Int, "Beijing" :: String)
+      [ taggedB "fmt"         $ \(n,city) -> "There are "#|n|#" million bicycles in "#|city|#"."
+      , taggedB "formattting" $ \(n,city) -> formatToString ("There are "%int%" million bicycles in "%string%".") n city
+      , taggedB "text-format" $ formatS "There are {} million bicycles in {}."
+      , taggedB "interpolate" $ \(n,city) -> [i|There are #{n} million bicycles in #{city}.|]
+      , taggedB "show"        $ \(n,city) -> "There are " ++ show n ++ " million bicycles in " ++ city ++ "."
+      , taggedB "printf"      $ \(n,city) -> printf "There are %d million bicycles in %s." n city
       ]
     ]
   ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -6,7 +6,9 @@
 
 module Main where
 
+import           Control.DeepSeq         (NFData)
 import           Data.Monoid             ((<>))
+import           Data.String             (IsString)
 import           Data.String.Interpolate (i)
 import           Data.Text               (Text)
 import qualified Data.Text               as T
@@ -14,10 +16,10 @@ import qualified Data.Text.Format        as TF
 import           Data.Text.Format.Params as TF
 import qualified Data.Text.Lazy          as LT
 import           Fmt                     (( #| ), (|#))
-import           Formatting              (int, sformat, (%))
+import           Formatting              (formatToString, int, sformat, (%))
 import           Text.Printf             (printf)
 
-import           Criterion               (Benchmark, Benchmarkable, bench, bgroup, nf)
+import           Criterion               (Benchmark, bench, bgroup, nf)
 import           Criterion.Main          (defaultMain)
 
 ----------------------------------------------------------------------------
@@ -27,6 +29,9 @@ import           Criterion.Main          (defaultMain)
 format' :: TF.Params ps => TF.Format -> ps -> Text
 format' f = LT.toStrict . TF.format f
 
+formatS :: TF.Params ps => TF.Format -> ps -> String
+formatS f = LT.unpack . TF.format f
+
 tshow :: Show a => a -> Text
 tshow x = T.pack (show x)
 
@@ -34,11 +39,17 @@ tshow x = T.pack (show x)
 -- Benchmarks utility functions
 ----------------------------------------------------------------------------
 
-simpleBench :: ((Int, Int) -> Text) -> Benchmarkable
-simpleBench fmt = nf fmt (1,2)
+bGenericStringGroup :: (NFData s, IsString s) => String -> a -> [(String, a -> s)] -> Benchmark
+bGenericStringGroup sTag benchObj = bgroup sTag . map (\(tag, fmt) -> bench tag (nf fmt benchObj))
+{-# INLINABLE bGenericStringGroup #-}
 
 bTextGroup :: a -> [(String, a -> Text)] -> Benchmark
-bTextGroup benchObj = bgroup "text" . map (\(tag, fmt) -> bench tag (nf fmt benchObj))
+bTextGroup = bGenericStringGroup "text"
+{-# INLINE bTextGroup #-}
+
+bStringGroup :: a -> [(String, a -> String)] -> Benchmark
+bStringGroup = bGenericStringGroup "string"
+{-# INLINE bStringGroup #-}
 
 -- Function for convenience instead of using manual @(,)@.
 taggedB :: String -> (a -> b) -> (String, a -> b)
@@ -47,11 +58,7 @@ taggedB = (,)
 ----------------------------------------------------------------------------
 -- Benchmakrs themselves
 ----------------------------------------------------------------------------
-{-
-bTextGroup
-[ ("fmt", \(a,b) -> "")
-]
--}
+
 main :: IO ()
 main = defaultMain
   [ bgroup "simple"
@@ -62,6 +69,14 @@ main = defaultMain
       , taggedB "interpolate" $ \(a,b) -> T.pack [i|hello #{a} world #{b}|]
       , taggedB "show"        $ \(a,b) -> "hello " <> tshow a <> " world " <> tshow b
       , taggedB "printf"      $ \(a,b) -> T.pack $ printf "hello %d world %d" a b
+      ]
+    , bStringGroup (1 :: Int, 2 :: Int)
+      [ taggedB "fmt"         $ \(a,b) -> "hello "#|a|#" world "#|b|#""
+      , taggedB "formattting" $ \(a,b) -> formatToString ("hello "%int%" world "%int) a b
+      , taggedB "text-format" $ formatS "hello {} world {}"
+      , taggedB "interpolate" $ \(a,b) -> [i|hello #{a} world #{b}|]
+      , taggedB "show"        $ \(a,b) -> "hello " ++ show a ++ " world " ++ show b
+      , taggedB "printf"      $ \(a,b) -> printf "hello %d world %d" a b
       ]
     ]
   ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,20 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
 
 -- | Benchmarks for @fmt@ library.
 
 module Main where
 
-import           Control.DeepSeq         (NFData)
 import           Data.Monoid             ((<>))
-import           Data.String             (IsString)
 import           Data.String.Interpolate (i)
 import           Data.Text               (Text)
 import qualified Data.Text               as T
 import qualified Data.Text.Format        as TF
-import           Data.Text.Format.Params (Params)
+import           Data.Text.Format.Params as TF
 import qualified Data.Text.Lazy          as LT
 import           Fmt                     (( #| ), (|#))
 import           Formatting              (int, sformat, (%))
@@ -23,22 +20,31 @@ import           Text.Printf             (printf)
 import           Criterion               (Benchmarkable, bench, bgroup, nf)
 import           Criterion.Main          (defaultMain)
 
-simpleBench :: (NFData s, IsString s) => ((Int, Int) -> s) -> Benchmarkable
+simpleBench :: ((Int, Int) -> Text) -> Benchmarkable
 simpleBench fmt = nf fmt (1,2)
 
-format' :: Params ps => TF.Format -> ps -> Text
+format' :: TF.Params ps => TF.Format -> ps -> Text
 format' f = LT.toStrict . TF.format f
+
+tshow :: Show a => a -> Text
+tshow x = T.pack (show x)
 
 main :: IO ()
 main = defaultMain
   [ bgroup "simple"
     [ bgroup "text"
-      [ bench "fmt" $ simpleBench @Text (\(a,b) -> "hello "#|a|#" world "#|b|#"")
-      , bench "fng" $ simpleBench @Text (\(a,b) -> sformat ("hello "%int%" world "%int) a b)
-      , bench "shw" $ simpleBench @Text (\(a,b) -> "hello " <> T.pack (show a) <> " world " <> T.pack (show b))
-      , bench "tft" $ simpleBench @Text (format' "hello {} world {} ")
-      , bench "prf" $ simpleBench @Text (\(a,b) -> T.pack $ printf "hello %d world %d" a b)
-      , bench "int" $ simpleBench @Text (\(a,b) -> T.pack [i|hello #{a} world #{b}|])
+      [ bench "fmt" $ simpleBench
+            (\(a,b) -> "hello "#|a|#" world "#|b|#"")
+      , bench "formatting" $ simpleBench
+            (\(a,b) -> sformat ("hello "%int%" world "%int) a b)
+      , bench "show" $ simpleBench
+            (\(a,b) -> "hello " <> tshow a <> " world " <> tshow b)
+      , bench "text-format" $ simpleBench
+            (format' "hello {} world {}")
+      , bench "printf" $ simpleBench
+            (\(a,b) -> T.pack $ printf "hello %d world %d" a b)
+      , bench "interpolate" $ simpleBench
+            (\(a,b) -> T.pack [i|hello #{a} world #{b}|])
       ]
     ]
   ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+
+-- | Benchmarks for @fmt@ library.
+
+module Main where
+
+import           Control.DeepSeq         (NFData)
+import           Data.Monoid             ((<>))
+import           Data.String             (IsString)
+import           Data.String.Interpolate (i)
+import           Data.Text               (Text)
+import qualified Data.Text               as T
+import qualified Data.Text.Format        as TF
+import           Data.Text.Format.Params (Params)
+import qualified Data.Text.Lazy          as LT
+import           Fmt                     (( #| ), (|#))
+import           Formatting              (int, sformat, (%))
+import           Text.Printf             (printf)
+
+import           Criterion               (Benchmarkable, bench, bgroup, nf)
+import           Criterion.Main          (defaultMain)
+
+simpleBench :: (NFData s, IsString s) => ((Int, Int) -> s) -> Benchmarkable
+simpleBench fmt = nf fmt (1,2)
+
+format' :: Params ps => TF.Format -> ps -> Text
+format' f = LT.toStrict . TF.format f
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "simple"
+    [ bgroup "text"
+      [ bench "fmt" $ simpleBench @Text (\(a,b) -> "hello "#|a|#" world "#|b|#"")
+      , bench "fng" $ simpleBench @Text (\(a,b) -> sformat ("hello "%int%" world "%int) a b)
+      , bench "shw" $ simpleBench @Text (\(a,b) -> "hello " <> T.pack (show a) <> " world " <> T.pack (show b))
+      , bench "tft" $ simpleBench @Text (format' "hello {} world {} ")
+      , bench "prf" $ simpleBench @Text (\(a,b) -> T.pack $ printf "hello %d world %d" a b)
+      , bench "int" $ simpleBench @Text (\(a,b) -> T.pack [i|hello #{a} world #{b}|])
+      ]
+    ]
+  ]

--- a/fmt.cabal
+++ b/fmt.cabal
@@ -75,7 +75,6 @@ test-suite tests
   build-depends:       base >=4.6 && <5
                      , bytestring
                      , containers
-                     , containers
                      , fmt
                      , hspec >= 2.2 && < 2.5
                      , neat-interpolation
@@ -83,6 +82,26 @@ test-suite tests
                      , vector
   ghc-options:         -Wall -fno-warn-unused-do-bind
   hs-source-dirs:      tests
+  default-language:    Haskell2010
+  if impl(ghc < 7.10)
+    buildable: False
+
+benchmark benches
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             Main.hs
+  build-depends:       base >=4.6 && <5
+                     , bytestring
+                     , containers
+                     , criterion
+                     , deepseq
+                     , fmt
+                     , formatting
+                     , interpolate
+                     , text
+                     , text-format
+                     , vector
+  ghc-options:         -Wall
   default-language:    Haskell2010
   if impl(ghc < 7.10)
     buildable: False

--- a/lib/Fmt.hs
+++ b/lib/Fmt.hs
@@ -38,7 +38,7 @@
 #  define _OVERLAPS_ {-# OVERLAPS #-}
 #endif
 
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Fmt
 (

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-8.6
+
+packages:
+- '.'
+
+extra-deps: []
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
This PR adds simple benchmarks suite for `fmt` library on `Text` and `String` types comparing with
* `formatting`
* `text-format`
* `interpolate`
* `printf` from `Text.Printf`
* simple `show`