### PR TITLE
Add Buildable instances for time-units

### DIFF
--- a/fmt.cabal
+++ b/fmt.cabal
@@ -56,6 +56,7 @@ source-repository head
 
 library
   exposed-modules:     Fmt
+                       Fmt.Instances
                        Fmt.Internal
   build-depends:       base >=4.6 && <5,
                        base16-bytestring,
@@ -64,8 +65,9 @@ library
                        containers,
                        microlens >= 0.3,
                        text,
-                       text-format >= 0.3
-  ghc-options:         -Wall -fno-warn-unused-do-bind
+                       text-format >= 0.3,
+                       time-units
+  ghc-options:         -Wall -fno-warn-unused-do-bind -fno-warn-orphans
   hs-source-dirs:      lib
   default-language:    Haskell2010
 
@@ -79,6 +81,7 @@ test-suite tests
                      , hspec >= 2.2 && < 2.5
                      , neat-interpolation
                      , text
+                     , time-units
                      , vector
   ghc-options:         -Wall -fno-warn-unused-do-bind
   hs-source-dirs:      tests

--- a/lib/Fmt.hs
+++ b/lib/Fmt.hs
@@ -178,6 +178,7 @@ import Data.Foldable (Foldable)
 import Data.List.NonEmpty (NonEmpty)
 #endif
 
+import Fmt.Instances ()
 import Fmt.Internal
 
 

--- a/lib/Fmt/Instances.hs
+++ b/lib/Fmt/Instances.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Module containin orphan 'Buildable' instances
+-- for different data types.
+
+module Fmt.Instances () where
+
+import           Data.Text.Buildable (Buildable (..))
+
+-- TODO: reexport time-units itself?
+import           Data.Time.Units     (Attosecond, Day, Femtosecond, Fortnight, Hour,
+                                      Microsecond, Millisecond, Minute, Nanosecond,
+                                      Picosecond, Second, Week)
+
+----------------------------------------------------------------------------
+-- time-units instances
+----------------------------------------------------------------------------
+
+instance Buildable Attosecond  where build = build . show
+instance Buildable Femtosecond where build = build . show
+instance Buildable Picosecond  where build = build . show
+instance Buildable Nanosecond  where build = build . show
+instance Buildable Microsecond where build = build . show
+instance Buildable Millisecond where build = build . show
+instance Buildable Second      where build = build . show
+instance Buildable Minute      where build = build . show
+instance Buildable Hour        where build = build . show
+instance Buildable Day         where build = build . show
+instance Buildable Week        where build = build . show
+instance Buildable Fortnight   where build = build . show

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,8 @@ resolver: lts-8.6
 packages:
 - '.'
 
-extra-deps: []
+extra-deps:
+- time-units-1.0.0
+
 flags: {}
 extra-package-dbs: []

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -8,6 +8,8 @@ module Main where
 
 -- Monoid
 import Data.Monoid ((<>))
+-- Time-Units
+import Data.Time.Units
 -- Text
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -180,6 +182,37 @@ test_conditionals = describe "conditionals" $ do
   it "unlessF" $ do
     unlessF True "hi" ==#> ""
     unlessF False "hi" ==#> "hi"
+
+----------------------------------------------------------------------------
+-- Tests for orphan instances of other libraries
+----------------------------------------------------------------------------
+
+test_timeUnits :: Spec
+test_timeUnits = describe "time-units" $ do
+    it "Attosecond" $
+        (""#|(0 :: Attosecond)|#"") ==#> "0as"
+    it "Femtosecond" $
+        (""#|(1 :: Femtosecond)|#"") ==#> "1fs"
+    it "Picosecond" $
+        (""#|(2 :: Picosecond)|#"") ==#> "2ps"
+    it "Nanosecond" $
+        (""#|(3 :: Nanosecond)|#"") ==#> "3ns"
+    it "Microsecond" $
+        (""#|(4 :: Microsecond)|#"") ==#> "4µs"  -- TODO: not use mu here to not break terminals?
+    it "Millisecond" $
+        (""#|(5 :: Millisecond)|#"") ==#> "5ms"
+    it "Second" $
+        (""#|(6 :: Second)|#"") ==#> "6s"
+    it "Minute" $
+        (""#|(7 :: Minute)|#"") ==#> "7m"
+    it "Hour" $
+        (""#|(8 :: Hour)|#"") ==#> "8h"
+    it "Day" $
+        (""#|(9 :: Day)|#"") ==#> "9d"
+    it "Week" $
+        (""#|(10 :: Week)|#"") ==#> "10w"
+    it "Fortnight" $
+        (""#|(11 :: Fortnight)|#"") ==#> "11fn"
 
 ----------------------------------------------------------------------------
 -- Tests for padding


### PR DESCRIPTION
This commit adds `Buildable` orphan instances for [`time-units`](http://hackage.haskell.org/package/time-units) package. I don't know, whether it's good idea, though instances are very dummy. But be careful of some shenanigans with greek letters. Last commit in `time-units` was 6 years ago. Maybe it's time to conquer  that package :)
